### PR TITLE
ci: skip image publishing for dependabot pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,6 @@ jobs:
           registry: ghcr.io/raeperd
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Get branch name
-        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr /# -)" >> $GITHUB_ENV
       - name: Build container image
         if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
-        run: ./gradlew jib -Djib.to.tags=${{ env.BRANCH_NAME }}
+        run: ./gradlew jib -Djib.to.tags="$BRANCH_NAME"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,14 +28,14 @@ jobs:
           path: build/libs/*.jar
 
       - uses: docker/login-action@v4
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
         with:
           registry: ghcr.io/raeperd
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Get branch name
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr /# -)" >> $GITHUB_ENV
       - name: Build container image
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
         run: ./gradlew jib -Djib.to.tags=${{ env.BRANCH_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,11 @@ jobs:
           registry: ghcr.io/raeperd
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get branch name
+        if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
+        run: |
+          BRANCH_NAME=$(printf '%s' "$GITHUB_REF_NAME" | tr '/#' '-')
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
       - name: Build container image
         if: github.event_name == 'push' && github.actor != 'dependabot[bot]'
         run: ./gradlew jib -Djib.to.tags="$BRANCH_NAME"


### PR DESCRIPTION
### Motivation
- Prevent Dependabot branch pushes from attempting GHCR login and Jib image publishing which can fail and break CI while still running the Gradle build validation for PRs and other pushes.

### Description
- Update `.github/workflows/build.yml` to add `&& github.actor != 'dependabot[bot]'` to the GHCR login, branch-name export, and Jib image build steps so Dependabot pushes skip image publishing.

### Testing
- Ran `JAVA_HOME=$HOME/.local/share/mise/installs/java/25.0.2 ./gradlew compileJava --info` which succeeded, attempted `./gradlew build --info` but it was blocked in this environment by HTTP 403 responses from Maven Central, and ran `git diff --check` before committing the workflow change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a467c87325c8333b253ef23dc368116)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow so container image build and publish steps run only on standard push events, not automated bot pushes.
  * Removed the prior branch-name retrieval step and adjusted tagging to use the generated `BRANCH_NAME` shell variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->